### PR TITLE
Initial import from incubator repo, misc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,249 @@
-# ansible-role-lxd-testenv
-Ansible role used to generate a LXD container test environment
+# Ansible Role: LXD Test Environment (lxd-testenv)
+
+Ansible role used to generate or teardown a
+[LXD](https://linuxcontainers.org/lxd/getting-started-cli/) container test
+environment. This role is intended to be used as a base for testing other
+roles and playbooks.
+
+[Example playbooks](#example-playbooks) for both use cases are provided.
+
+## Limitations
+
+- Tested on Ubuntu 16.04+ only
+  - *support for other distros may be added in a future release*
+
+- This version of the role assumes that the calling playbook provides a host
+  list *and* sets the `serial: 1` option
+  - each inventory host needs to be processed serially in order to prevent
+    race conditions; testing has shown that simultaneous calls to some of the
+    modules used (e.g., `known_hosts`) causes race conditions which results in
+    data corruption
+
+Future versions of this role are intended to better handle these issues.
+
+## WARNINGS
+
+- Do not use this role on production systems. It lacks sufficient testing to
+  be relied upon for anything more than local/isolated testing purposes.
+
+## Requirements
+
+- Ubuntu 16.04 or newer
+- [LXD packages](https://linuxcontainers.org/lxd/getting-started-cli/)
+  installed
+- Equivalent of `sudo lxd init` already run
+  - note: the The [`atc0005.lxd-host`
+    role](https://github.com/atc0005/ansible-role-lxd-host) role is intended
+    to handle this, though as of this writing that role is still incomplete
+
+## Role Variables
+
+- The `state` variable is set outside of the role to act as a control flag for
+  either building up a test environment or tearing it down.
+  - valid values are `create` or `remove`
+- Role variables are set within `default/main.yml`.
+
+| Variable                                     | Default value                        | Purpose                                                                                                                                                                                                                                                                                               |
+| -------------------------------------------- | :----------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lxd_host_ssh_known_hosts_file`              | `$HOME/.ssh/known_hosts`             | Host copy of file. Updated to reflect host keys of all containers.                                                                                                                                                                                                                                    |
+| `lxd_host_update_known_hosts_file`           | `true`                               | Controls whether the `lxd_host_ssh_known_hosts_file` file on the host is updated with host keys from all containers.                                                                                                                                                                                  |
+| `lxd_host_update_etc_hosts_file`             | `true`                               | Controls whether the `/etc/hosts` file on the LXD container host is updated to include new container name/IP pairs                                                                                                                                                                                    |
+| `lxd_host_ssh_private_key_for_containers`    | `$HOME/.ssh/id_ed25519`              | Generated if it does not exist. See notes for public key.                                                                                                                                                                                                                                             |
+| `lxd_host_ssh_public_key_for_containers`     | `$HOME/.ssh/id_ed25519.pub`          | Inserted into `root` and `ansible` user profiles within each container.                                                                                                                                                                                                                               |
+| `lxd_host_remove_container_settings`         | `false`                              | Controls whether this role removes `lxd_host_ssh_known_hosts_file` and `/etc/hosts` entries as part of teardown tasks. Usually, but not required to be performed along with container removal. Defaults to `false`                                                                                    |
+| `lxd_host_remove_containers`                 | `false`                              | Controls whether containers are removed as part of teardown process. Defaults to `false`.                                                                                                                                                                                                             |
+| `lxd_containers_update_hosts_file`           | `false`                              | Controls whether `/etc/hosts` within containers are updated to include entries for *all* containers generated by this role. Since the LXD-provided dnsmasq instance bound to the bridge already handles name resolution, this option is not really needed and may be removed in a future role update. |
+| `lxd_containers_image_server`                | <https://images.linuxcontainers.org> | Server listed in the Ansible module examples. Used to fetch LXD container images for generating fresh containers.                                                                                                                                                                                     |
+| `lxd_containers_create`                      | `true`                               | Controls whether containers are generated when this role is run. **TODO**: Validation is needed to assert that this is not set at the same time as the flag for removing containers.                                                                                                                  |
+| `lxd_containers_bootstrap`                   | `true`                               | Controls whether Python, sudo and other packages are installed as part of preparing new containers for management by Ansible.                                                                                                                                                                         |
+| `lxd_containers_configure`                   | `true`                               | Create service account, groups, enable SSH at boot, etc                                                                                                                                                                                                                                               |
+| `lxd_containers_packages_required`           | `openssh-server`, `sudo`             | Packages installed as part of the *bootstrap* process for new containers                                                                                                                                                                                                                              |
+| `lxd_containers_packages_extra`              | `nano`                               | Ensure that a sensible (j/k) editor is available in newly created containers                                                                                                                                                                                                                          |
+| `lxd_containers_profiles`                    | `default`                            | LXD profiles applied to all new containers by default.                                                                                                                                                                                                                                                |
+| `docker_main_config_file`                    | `/etc/docker/daemon.json`            | Path to Docker "daemon" configuration file. Role-provided template for this file configures the active storage driver used within new containers intended to test Docker workflows.                                                                                                                   |
+| `lxd_containers_docker_config_file_template` | `docker-daemon-config.json.j2`       | Template file included with role used for setting Docker daemon storage driver.                                                                                                                                                                                                                       |
+| `lxd_containers_docker_storage_driver`       | `vfs`                                | Docker storage drivers: `overlay2` is incompatible with LXD LTS (2.0, 3.0), `overlay` is incompatible with ZFS backed LXD storage. `vfs` is slow, but compatible with both. Override this from a playbook (or other higher level Ansible variable source) if not using ZFS for better performance.    |
+| `lxd_containers_sudoers_include_file`        | `/etc/sudoers.d/ansible`             | Location of sudoers include file used to grant service account full sudo privileges within new containers                                                                                                                                                                                             |
+| `lxd_containers_service_account`             | `ansible`                            | Service account created within containers that is granted full sudo privileges. Often used by playbooks as a dedicated remote management account.                                                                                                                                                     |
+| `lxd_containers_service_group`               | `ansible`                            | Service group that goes with the service account already noted here.                                                                                                                                                                                                                                  |
+| `state`                                      | `create`                             | Flag with valid values of `create` or `remove`. Used to control whether a test environment will be created or removed/destroyed.                                                                                                                                                                      |
+| `default_python_install_command`             | *see example below*                  | Crude one-liner shell command to use appropriate package manager to install Python for Ansible use via a `raw` command.                                                                                                                                                                               |
+| `python_path`                                | `/usr/bin/python`                    | Location of Python interpreter used by Ansible on remote hosts (containers in our case).                                                                                                                                                                                                              |
+
+Default shell command for the `default_python_install_command` variable:
+
+```shell
+if [[ $? -ne 0 ]]; then
+  if [[ -f /usr/bin/apt-get ]]; then
+    apt-get install -y python;
+  fi
+  if [[ -f /usr/bin/yum ]]; then
+    yum install -y python;
+  fi
+fi
+```
+
+If not set elsewhere and if Python 2.x is not found on the system as
+`/usr/bin/python`, the above command is used in an attempt to install Python 2
+for further Ansible management steps.
+
+## Dependencies
+
+An existing installation of [LXD
+packages](https://linuxcontainers.org/lxd/getting-started-cli/) and initial
+configuration via `sudo lxd init`. The [`atc0005.lxd-host`
+role](https://github.com/atc0005/ansible-role-lxd-host) is intended to serve
+that purpose in the future once it is ready.
+
+See [Requirements](#requirements) section for additional items.
+
+## Example Playbooks
+
+### Setup test environment
+
+**WARNING:** Review known [Limitations](#limitations) before using this role.
+
+```yaml
+
+- name: Configure base LXD host
+  hosts: localhost
+  connection: local
+
+  # Should be fine to gather facts for just the future LXD host
+  gather_facts: yes
+
+  tasks:
+
+    # Stub role for now. Later work will have it install required packages
+    # needed in order to configure host system for running LXD containers
+    - name: Apply lxd-host role to install LXD packages, perform initial setup
+      import_role:
+        name: atc0005.lxd-host
+
+- name: Setup LXD test environment
+  hosts: all
+  connection: local
+
+  # This is needed due to potential for multiple access attempts via modules
+  # that are not intended/designed for it. Without this setting occasional
+  # race conditions occur which results in data corruption.
+  serial: 1
+
+  # Rely on specific tasks to call setup module as needed
+  gather_facts: no
+
+  tasks:
+
+    # Default role settings handle creation; we have to explicitly enable
+    # container/settings removal tasks
+    - name: Apply lxd-testenv role to create test environment
+      import_role:
+        name: atc0005.lxd-testenv
+      vars:
+        # Valid values: "create" and "remove"
+        state: "create"
+```
+
+### Teardown/Remove test environment
+
+**WARNING:** Review known [Limitations](#limitations) before using this role.
+
+```yaml
+
+- name: Tear down our LXD test environment
+  hosts: all
+  connection: local
+  gather_facts: no
+
+  # This is needed due to potential for multiple access attempts via modules
+  # that are not intended/designed for it. Without this setting occasional
+  # race conditions occur which results in data corruption.
+  serial: 1
+
+  tasks:
+
+    - name: Apply lxd-testenv role
+      import_role:
+        name: atc0005.lxd-testenv
+      vars:
+        # Valid values: "create" and "remove"
+        state: "remove"
+        lxd_host_remove_container_settings: true
+        lxd_host_remove_containers: true
+
+```
+
+## Installing the role
+
+### Create `requirements.yml` file
+
+Note: This role is not yet availalble via Ansible Galaxy, so for now you will
+need to install it via a `requirements.yml` file.
+
+#### Specific stable release version
+
+```yaml
+---
+
+- name: "atc0005.lxd-testenv"
+  src: https://github.com/atc0005/ansible-role-lxd-testenv.git"
+  version: "v1.0"
+
+...
+
+```
+
+#### Latest from the `master` branch
+
+Example `requirements.yml` file that uses the latest from the `master` branch:
+
+```yaml
+---
+
+- name: "atc0005.lxd-testenv"
+  src: https://github.com/atc0005/ansible-role-lxd-testenv.git"
+  version: "master"
+
+...
+
+```
+
+### Use `requirements.yml` file to install role
+
+- Because `ansible-galaxy` does not yet natively support updating existing
+  roles, the example installation instructions provided below include the
+  `--force` parameter to *force* pulling in the latest updates as directed by
+  the `requirements.yml` file.
+
+#### Option 1: Within your home directory
+
+- `ansible-galaxy install -r requirements.yml --force`
+
+#### Option 2: Within a `roles` directory in the same location as your playbooks
+
+- `ansible-galaxy install -r requirements.yml -p roles --force`
+
+#### Option 3: System-wide for all users
+
+- `sudo ansible-galaxy install -r requirements.yml --force`
+
+## License
+
+MIT
+
+## Author Information
+
+This role was created in 2019 by Adam Chalkley as part of building an
+on-demand development environment toolkit managed by Ansible.
+
+## References
+
+- <https://github.com/atc0005/ansible-playbooks>
+- <https://github.com/atc0005/ansible-role-lxd-host>
+- <https://github.com/atc0005/ansible-role-lxd-testenv>
+- <https://github.com/atc0005/ansible-role-docker-host>
+
+- <https://linuxcontainers.org/lxd/getting-started-cli/>
+
+- <https://docs.ansible.com/ansible/latest/modules/lxd_container_module.html>
+- <https://docs.ansible.com/ansible/latest/modules/lxd_profile_module.html>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,86 @@
+---
+
+# vim: ts=2:sw=2:et:ft=ansible
+# -*- mode: ansible; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=ansible insertSpaces=true tabSize=2
+
+
+# Host copy of file. Updated to reflect host keys of all containers.
+lxd_host_ssh_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
+
+# By default, update the $HOME/.ssh/known_hosts file on the host with host
+# keys from all containers.
+lxd_host_update_known_hosts_file: true
+
+# Flag used to control whether the `/etc/hosts` file on the LXD container host
+# is updated to include new container name/IP pairs
+lxd_host_update_etc_hosts_file: true
+
+# Keys specific/dedicated to this role
+
+lxd_host_ssh_private_key_for_containers: "{{ lookup('env','HOME') + '/.ssh/id_ed25519' }}"
+lxd_host_ssh_public_key_for_containers: "{{ lxd_host_ssh_private_key_for_containers + '.pub' }}"
+
+# by default this role serves as a setup tool, but this can be
+# overridden to tear down the test environment
+lxd_host_remove_container_settings: false
+lxd_host_remove_containers: false
+
+# Should the /etc/hosts file on each container be updated to list all other
+# containers? If this is not enabled, then built-in dnsmasq support will be
+# used to provide name resolution between containers.
+lxd_containers_update_hosts_file: false
+
+# Server listed in the Ansible module examples
+lxd_containers_image_server: "https://images.linuxcontainers.org"
+
+# Assume that containers should be created when this role is used
+# unless overridden
+lxd_containers_create: true
+
+# Flag that controls whether Python, sudo and other packages are installed as
+# part of preparing new containers for management by Ansible.
+lxd_containers_bootstrap: true
+
+# Create service account, groups, enable SSH at boot, etc
+lxd_containers_configure: true
+
+lxd_containers_packages_required:
+  - "openssh-server"
+  - "sudo"
+lxd_containers_packages_extra:
+  # mainly a placeholder, but useful on its own
+  - "nano"
+
+# All profiles listed here will be applied to newly created containers
+lxd_containers_profiles:
+  - "default"
+
+# https://docs.docker.com/config/daemon/
+docker_main_config_file: "/etc/docker/daemon.json"
+lxd_containers_docker_config_file_template: "docker-daemon-config.json.j2"
+
+# See Docker storage drivers for valid options, BUT know that some may not
+# work within a LXD/LXD environment. The default value chosen here is 'vfs' in
+# order to provide the broadest compatibility with backing storage filesystems,
+# but this default option should be overridden by the role user if performance
+# is found to not be sufficient. Aside from 'vfs', the 'overlay' Docker storage
+# driver has been found to be compatible, provided that you are not using ZFS
+# as the the LXD storage option.
+# https://github.com/lxc/lxd/issues/2305
+# https://docs.docker.com/storage/storagedriver/select-storage-driver/
+lxd_containers_docker_storage_driver: "vfs"
+
+lxd_containers_sudoers_include_file: "/etc/sudoers.d/ansible"
+lxd_containers_service_account: "ansible"
+lxd_containers_service_group: "ansible"
+
+# Default state is setting up a test environment
+state: "create"
+
+default_python_install_command: "if [[ $? -ne 0 ]]; then if [[ -f /usr/bin/apt-get ]]; then apt-get install -y python; fi; if [[ -f /usr/bin/yum ]]; then yum install -y python; fi; fi"
+
+# Location of Python 2 interpreter; needed for bootstrap testing purposes
+python_path: "/usr/bin/python"
+
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for roles/lxd-testenv

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,60 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/tasks/containers-bootstrap.yml
+++ b/tasks/containers-bootstrap.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Confirm python is installed in container
+  raw: "test -e {{ python_path }}"
+  register: python_install_check
+  failed_when: python_install_check.rc not in [0, 1]
+  changed_when: false
+
+# Triggered when -vvvv is specified
+# https://docs.ansible.com/ansible/latest/modules/debug_module.html
+- name: DEBUG | Display all known facts about host
+  debug:
+    var: hostvars[inventory_hostname]
+    verbosity: "4"
+
+# Triggered when -vv is specified
+- name: DEBUG | Show python check results
+  debug:
+    var: python_install_check.stdout
+    verbosity: "2"
+
+# Only occurs with containers without Python
+- name: Install Python
+  # TODO: not sure I have the syntax right here
+  raw: "{{ python_install_command | default(default_python_install_command) }}"
+  when:
+    - python_install_check.rc == 1
+
+...

--- a/tasks/containers-configure.yml
+++ b/tasks/containers-configure.yml
@@ -1,0 +1,76 @@
+---
+
+- name: Create service group
+  group:
+    name: "{{ lxd_containers_service_group }}"
+    state: present
+    system: no
+
+- name: Create service user
+  user:
+    name: "{{ lxd_containers_service_account }}"
+    # Explicitly specify this in case the default behavior ever changes
+    # Credit: @auadamw
+    create_home: yes
+    comment: Service account used by Ansible to configure system
+    group: "{{ lxd_containers_service_group }}"
+    state: present
+    system: no
+
+- name: "Create service account sudoers file in container"
+  copy:
+    content: '{{ lxd_containers_service_account }} ALL=(ALL) NOPASSWD: ALL'
+    dest: "{{ lxd_containers_sudoers_include_file }}"
+    owner: root
+    group: root
+    mode: 0440
+
+- name: Deploy SSH Public key for container management
+  block:
+
+    - name: Load SSH public key for containers from current user profile
+      set_fact:
+        lxd_host_ssh_public_key_for_containers_content: >-
+          {{ lookup('file', lxd_host_ssh_public_key_for_containers) }}
+
+    - name: Deploy current user SSH public key to specific users in container
+      authorized_key:
+        user: "{{ item }}"
+        state: present
+        key: "{{ lxd_host_ssh_public_key_for_containers_content }}"
+      register: authorized_key_insert_output
+      with_items:
+        - root
+        - ansible
+
+  rescue:
+
+    - name: DEBUG | Display public key contents intended for container management
+      debug:
+        var: lxd_host_ssh_public_key_for_containers_content
+
+    - name: DEBUG | Display authorized_key insertion results
+      debug:
+        var: authorized_key_insert_output
+
+    - fail:
+        msg: "Failed to deploy key to users in containers"
+
+
+- name: Start SSH, set it to start at boot
+  service:
+    name: sshd
+    state: started
+    enabled: yes
+
+- name: "Update hosts file in container"
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*{{ inventory_hostname }}$'
+    line: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }} {{ inventory_hostname }}"
+    state: present
+  when:
+    - hostvars[inventory_hostname].ansible_default_ipv4.address is defined
+    - lxd_containers_update_hosts_file
+
+...

--- a/tasks/containers-deploy-docker-config.yml
+++ b/tasks/containers-deploy-docker-config.yml
@@ -1,0 +1,29 @@
+---
+
+# Purpose: Install Docker related configuration in containers that may be used
+# for Docker testing. A separate role is used to actually install Docker and
+# related packages into those containers
+
+- name: DOCKER | Create config file directory
+  become: yes
+  file:
+    state: directory
+    dest: "{{ docker_main_config_file | dirname }}"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: DOCKER | DEBUG | Display chosen storage driver
+  debug:
+    var: lxd_containers_docker_storage_driver
+
+- name: DOCKER | Deploy base config file
+  become: yes
+  template:
+    src: '{{ lxd_containers_docker_config_file_template }}'
+    dest: "{{ docker_main_config_file }}"
+    owner: root
+    group: root
+    mode: 0644
+
+...

--- a/tasks/containers-install-extra-packages.yml
+++ b/tasks/containers-install-extra-packages.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Install extra packages
+  package:
+    name: "{{ lxd_containers_packages_extra }}"
+    state: present
+
+
+...

--- a/tasks/containers-install-required-packages.yml
+++ b/tasks/containers-install-required-packages.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Install required packages
+  package:
+    name: "{{ lxd_containers_packages_required }}"
+    state: present
+
+...

--- a/tasks/containers-start.yml
+++ b/tasks/containers-start.yml
@@ -1,0 +1,21 @@
+---
+
+# make sure all containers are running so that we can retrieve relevant
+# info and then prune that info from the host (e.g., known_hosts, /etc/hosts)
+- name: Ensure containers are running so we can pull required details
+  delegate_to: localhost
+
+  # The user may have opted to nuke containers on their own outside of
+  # playbook control, so don't bomb out if a container is missing
+  ignore_errors: yes
+
+  lxd_container:
+    name: "{{ inventory_hostname }}"
+    state: started
+    wait_for_ipv4_addresses: true
+    timeout: 600
+  when: lxd_host_remove_containers
+  tags:
+    - remove
+
+...

--- a/tasks/create-test-environment.yml
+++ b/tasks/create-test-environment.yml
@@ -1,0 +1,41 @@
+---
+
+# vim: ts=2:sw=2:et:ft=ansible
+# -*- mode: ansible; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=ansible insertSpaces=true tabSize=2
+
+- name: HOST | Create custom LXD container profiles
+  import_tasks: host-create-lxd-profiles.yml
+
+- name: HOST | Create key pair for LXD container management
+  import_tasks: host-generate-ssh-keypair.yml
+
+- name: HOST | Create LXD containers
+  import_tasks: host-create-containers.yml
+
+- name: CONTAINERS | Bootstrap containers
+  import_tasks: containers-bootstrap.yml
+
+# https://groups.google.com/forum/#!topic/Ansible-project/n5bYP5BIbcQ
+- name: Gather facts after finishing container bootstrapping
+  setup:
+  become: no
+  # Any special meaning for this variable name?
+  register: setup
+
+- name: CONTAINERS | Install required packages
+  import_tasks: containers-install-required-packages.yml
+
+- name: CONTAINERS | Basic configuration
+  import_tasks: containers-configure.yml
+
+- name: CONTAINERS | Deploy Docker configuration
+  import_tasks: containers-deploy-docker-config.yml
+
+- name: CONTAINERS | Install additional packages
+  import_tasks: containers-install-extra-packages.yml
+
+- name: HOST | Apply settings to ease container management
+  import_tasks: host-add-container-settings.yml
+
+...

--- a/tasks/host-add-container-settings.yml
+++ b/tasks/host-add-container-settings.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Remove any residual container entries from /etc/hosts file
+  import_tasks: host-remove-etc-hosts-entries.yml
+
+- name: Remove any residual container entries from known_hosts file
+  import_tasks: host-remove-known_hosts-entries.yml
+
+# Generate /etc/hosts with Ansible
+# https://gist.github.com/rothgar/8793800
+- name: "Update hosts file on LXD host"
+  delegate_to: localhost
+  become: yes
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*{{ inventory_hostname }}$'
+    line: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }} {{ inventory_hostname }}"
+    state: present
+  when:
+    - hostvars[inventory_hostname].ansible_default_ipv4.address is defined
+    - lxd_host_update_etc_hosts_file
+
+# https://stackoverflow.com/questions/30226113/ansible-ssh-prompt-known-hosts-issue
+- name: Scan each host for its ssh public key
+  delegate_to: localhost
+  become: no
+  shell: |
+    #ssh-keyscan -H {{ hostvars[inventory_hostname].inventory_hostname }},{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}
+    ssh-keyscan {{ inventory_hostname }},{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}
+  register: ssh_known_host_results
+  changed_when: ssh_known_host_results.rc != 0
+  failed_when: ssh_known_host_results.rc != 0
+  when:
+    - hostvars[inventory_hostname].ansible_default_ipv4.address is defined
+    - lxd_host_update_known_hosts_file
+
+- name: Add/update the public key in the '{{ lxd_host_ssh_known_hosts_file }}'
+  delegate_to: localhost
+  known_hosts:
+    name: "{{ inventory_hostname }}"
+    key: "{{ item }}"
+    path: "{{ lxd_host_ssh_known_hosts_file }}"
+  when:
+    - lxd_host_update_known_hosts_file
+  with_items: "{{ ssh_known_host_results.stdout_lines }}"
+
+...

--- a/tasks/host-create-containers.yml
+++ b/tasks/host-create-containers.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Create containers and display the results
+  block:
+    - name: Create containers
+      delegate_to: localhost
+      lxd_container:
+        name: "{{ inventory_hostname }}"
+        state: started
+        source:
+          type: image
+          mode: pull
+          server: "{{ lxd_containers_image_server }}"
+          protocol: lxd
+          alias: "{{ hostvars[inventory_hostname]['lxd_image_source'] }}"
+        profiles: "{{ lxd_containers_profiles }}"
+        wait_for_ipv4_addresses: true
+        timeout: 600
+      register: container_creation_results
+  always:
+  - name: Display container creation results
+    debug:
+      var: container_creation_results
+      verbosity: 1
+  tags:
+    - create
+
+...

--- a/tasks/host-create-lxd-profiles.yml
+++ b/tasks/host-create-lxd-profiles.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Create LXD profile to enable Docker use in containers
+  delegate_to: localhost
+
+  # Attempt to limit runs to once per playbook run instead of for every node
+  # that the playbook targets.
+  run_once: true
+  lxd_profile:
+    name: docker
+    state: present
+    config: {"security.nesting": "true"}
+    description: Allow use of Docker in LXD containers
+
+...

--- a/tasks/host-generate-ssh-keypair.yml
+++ b/tasks/host-generate-ssh-keypair.yml
@@ -1,0 +1,43 @@
+---
+
+- name: Run ssh-keygen command, force display results in case of error
+  block:
+
+    - name: DEBUG | Display ssh-keygen command used to generate key for container use
+      debug:
+        verbosity: 2
+        msg: >
+          ssh-keygen
+          -q
+          -t ed25519
+          -f {{ lxd_host_ssh_private_key_for_containers }}
+          -C 'Key pair used for LXD container management'
+          -N ''
+
+    # https://serverfault.com/questions/910071/how-to-generate-host-ssh-keys-via-ansible
+    - name: Generate key for test environment container use
+      delegate_to: localhost
+      run_once: true
+      command : >
+        ssh-keygen
+        -q
+        -t ed25519
+        -f '{{ lxd_host_ssh_private_key_for_containers }}'
+        -C 'Key pair used for LXD container management'
+        -N ''
+      args:
+        creates: "{{ lxd_host_ssh_private_key_for_containers }}"
+      register: keygen_results
+
+  rescue:
+
+    - name: DEBUG | Display ssh-keygen command results
+      debug:
+        var: keygen_results
+
+    - fail:
+        msg: >
+          Failed to generate key pair for container managment.
+          See earlier debug output for details.
+
+...

--- a/tasks/host-remove-container-settings.yml
+++ b/tasks/host-remove-container-settings.yml
@@ -1,0 +1,21 @@
+---
+
+# make sure all containers are running so that we can retrieve relevant
+# info and then prune that info from the host (e.g., known_hosts, /etc/hosts)
+- name: Ensure containers are running so we can pull required details
+  import_tasks: containers-start.yml
+
+# https://groups.google.com/forum/#!topic/Ansible-project/n5bYP5BIbcQ
+- name: Gather facts so we can remove matching entries from host configuration
+  setup:
+  become: no
+  # Any special meaning for this variable name?
+  register: setup
+
+- name: Remove container entries from /etc/hosts file
+  import_tasks: host-remove-etc-hosts-entries.yml
+
+- name: Remove container entries from known_hosts file
+  import_tasks: host-remove-known_hosts-entries.yml
+
+...

--- a/tasks/host-remove-containers.yml
+++ b/tasks/host-remove-containers.yml
@@ -1,0 +1,28 @@
+---
+
+# make sure all containers are running so that we can retrieve relevant
+# info and then prune that info from the host (e.g., known_hosts, /etc/hosts)
+- name: Ensure containers are running so we can pull required details
+  import_tasks: containers-start.yml
+
+- name: Stop containers
+  delegate_to: localhost
+  lxd_container:
+    name: "{{ inventory_hostname }}"
+    state: stopped
+    timeout: 90
+  when: lxd_host_remove_containers
+  tags:
+    - remove
+
+- name: Delete containers
+  delegate_to: localhost
+  lxd_container:
+    name: "{{ inventory_hostname }}"
+    state: absent
+    timeout: 90
+  when: lxd_host_remove_containers
+  tags:
+    - remove
+
+...

--- a/tasks/host-remove-etc-hosts-entries.yml
+++ b/tasks/host-remove-etc-hosts-entries.yml
@@ -1,0 +1,23 @@
+---
+
+- name: DEBUG | Display regex pattern
+  delegate_to: localhost
+  debug:
+    msg: "Pattern: '.*{{ inventory_hostname }}$'"
+    verbosity: "1"
+  when: lxd_host_update_etc_hosts_file
+  tags:
+    - remove
+
+- name: "Remove container entries from hosts file on LXD host"
+  delegate_to: localhost
+  become: yes
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*{{ inventory_hostname }}$'
+    state: absent
+  when: lxd_host_update_etc_hosts_file
+  tags:
+    - remove
+
+...

--- a/tasks/host-remove-known_hosts-entries.yml
+++ b/tasks/host-remove-known_hosts-entries.yml
@@ -1,0 +1,29 @@
+---
+
+# Note: If setting 'hosts' for this play to anything but localhost, make
+# sure to set 'serial: 1' in order to avoid race conditions
+# (refs atc0005/ansible-playbooks#11)
+- name: "Remove container hostkeys from known_hosts file on LXD host via IP Address"
+  delegate_to: localhost
+  become: no
+  known_hosts:
+    path: "{{ lxd_host_ssh_known_hosts_file }}"
+    name: "{{ hostvars[inventory_hostname].ansible_default_ipv4.address }}"
+    state: absent
+  when: lxd_host_update_known_hosts_file
+  tags:
+    - remove
+
+- name: "Remove container hostkeys from known_hosts file on LXD host via hostname"
+  delegate_to: localhost
+  become: no
+  known_hosts:
+    path: "{{ lxd_host_ssh_known_hosts_file }}"
+    name: "{{ inventory_hostname }}"
+    state: absent
+  when: lxd_host_update_known_hosts_file
+  tags:
+    - remove
+
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+# vim: ts=2:sw=2:et:ft=yaml
+# -*- mode: yaml; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=yaml insertSpaces=true tabSize=2
+
+# https://github.com/atc0005/ansible-playbooks
+
+- name: "Import tasks to {{ state }} test environment"
+  import_tasks: "{{ state }}-test-environment.yml"
+
+...

--- a/tasks/remove-test-environment.yml
+++ b/tasks/remove-test-environment.yml
@@ -1,0 +1,13 @@
+---
+
+# vim: ts=2:sw=2:et:ft=ansible
+# -*- mode: ansible; indent-tabs-mode: nil; tab-width: 2 -*-
+# code: language=ansible insertSpaces=true tabSize=2
+
+- name: Remove LXD container settings
+  import_tasks: host-remove-container-settings.yml
+
+- name: Remove LXD containers
+  import_tasks: host-remove-containers.yml
+
+...

--- a/templates/docker-daemon-config.json.j2
+++ b/templates/docker-daemon-config.json.j2
@@ -1,0 +1,3 @@
+{
+  "storage-driver": "{{ lxd_containers_docker_storage_driver }}"
+}

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/lxd-testenv

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for roles/lxd-testenv


### PR DESCRIPTION
- Basic README coverage for default variables, example playbooks.
- Prune old/unused variables, add refs to related repos
- Default `vfs` Docker storage option with README suggestion to override this with a Docker storage option compatible with the role user's LXD storage configuration

Note: This is a mostly feature-complete, working role, but I'm already planning on changing large chunks of the playbook in an effort to simplify the steps and (hopefully) increase the deployment speed.


- refs atc0005/ansible-playbooks#15
- fixes atc0005/ansible-role-lxd-testenv#3
- fixes atc0005/ansible-role-lxd-testenv#4
