### PR TITLE
Update container creation proxy env var config

### DIFF
--- a/tasks/host-create-containers.yml
+++ b/tasks/host-create-containers.yml
@@ -21,10 +21,16 @@
         state: started
         # Allow overriding proxy server per host or group, fallback to role
         # default of empty string if not set
+        # https://unix.stackexchange.com/questions/212894/whats-the-right-format-for-the-http-proxy-environment-variable-caps-or-no-ca
         config:
           "environment.http_proxy": "{{ lxd_containers_proxy_server }}"
           "environment.https_proxy": "{{ lxd_containers_proxy_server }}"
           "environment.ftp_proxy": "{{ lxd_containers_proxy_server }}"
+          "environment.no_proxy": "localhost,127.0.0.1,localaddress,.localdomain.com"
+          "environment.HTTP_PROXY": "{{ lxd_containers_proxy_server }}"
+          "environment.HTTPS_PROXY": "{{ lxd_containers_proxy_server }}"
+          "environment.FTP_PROXY": "{{ lxd_containers_proxy_server }}"
+          "environment.NO_PROXY": "localhost,127.0.0.1,localaddress,.localdomain.com"
         source:
           type: "{{ lxd_containers_source_type }}"
           mode: "{{ lxd_containers_source_mode }}"


### PR DESCRIPTION
Changes:

- Include uppercase variations of proxy variables for apps which require them

- Explicitly set "no proxy" vars to help prevent redirecting localhost resource requests on to configured proxy

These changes complement the changes already applied in 4d78e9d112ece14ac5b8f9117bb8ecdc9335884e which set required settings in the  /etc/environment file which are used by SSH-based logins to configured containers.

These changes are applied to connections made by the LXC client/and/or the API access used by the lxd_container Ansible module.

- fixes #38
- refs #39