### PR TITLE
Run ssh key pair gen command once

### DIFF
--- a/tasks/host-generate-ssh-keypair.yml
+++ b/tasks/host-generate-ssh-keypair.yml
@@ -25,10 +25,8 @@
     # https://serverfault.com/questions/910071/how-to-generate-host-ssh-keys-via-ansible
     - name: Generate key for test environment container use
       delegate_to: localhost
-      # Allow to run for each host, trusting in 'creates' to prevent
-      # overwriting of existing key. This allows for a unique key per
-      # container.
-      # run_once: true
+      # Run task only once; this key is used with all test containers
+      run_once: true
       command : >
         ssh-keygen
         -q


### PR DESCRIPTION
The documentation already notes that this is not a per-container setting, so instead of fighting to implement a reliable per-container setting that nobody may use, go with the initial idea of sharing the key pair for access to all containers. 

If the other approach is needed later I can implement the feature then.

fixes #43