### PR TITLE
Include python-apt pkg with initial Python install

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Current shell command for the `lxd_containers_default_python_install_command` va
 
 ```shell
 if [ -f /usr/bin/apt-get ]; then
-  apt-get install -y python;
+  apt-get install -y python python-apt;
 fi
 if [ -f /usr/bin/yum ]; then
   yum install -y python;

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -218,7 +218,7 @@ lxd_containers_service_group: "ansible"
 # Default state is setting up a test environment
 state: "create"
 
-lxd_containers_default_python_install_command: "if [ -f /usr/bin/apt-get ]; then apt-get install -y python; fi; if [ -f /usr/bin/yum ]; then yum install -y python; fi"
+lxd_containers_default_python_install_command: "if [ -f /usr/bin/apt-get ]; then apt-get install -y python python-apt; fi; if [ -f /usr/bin/yum ]; then yum install -y python; fi"
 
 # Location of Python 2 interpreter; needed for bootstrap testing purposes
 lxd_containers_python_path: "/usr/bin/python"


### PR DESCRIPTION
This resolves the warning that this Ansible dependency is not present in later task steps.

fixes GH-50